### PR TITLE
First working prototype - DHCPv4

### DIFF
--- a/dhcp-relay/Makefile
+++ b/dhcp-relay/Makefile
@@ -4,6 +4,7 @@ USER_TARGETS := dhcp_user_xdp
 BPF_TARGETS :=dhcp_kern_xdp 
 EXTRA_DEPS := dhcp-relay.h
 #EXTRA_CFLAGS := $(if $(IPV6),-DIPV6)
+EXTRA_CFLAGS := -fno-builtin
 
 LIB_DIR = ../lib
 

--- a/dhcp-relay/cleanup_test.sh
+++ b/dhcp-relay/cleanup_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# -x
+
+OUTER_VLAN=83
+INNER_VLAN=20
+UPLINK_VLAN=84
+IF="ens6f0"
+
+DHCP_SERVER="185.107.12.59"
+IPADDR_BNG="194.45.77.57"
+IPADDR_UPLINK="185.107.12.99"
+CLIENT_IP="194.45.77.59"
+
+echo "Unloading XDP program"
+./dhcp_user_xdp -i $IF -d $DHCP_SERVER -s $IPADDR_BNG -u
+
+echo "Deleting VLAN interfaces"
+# Delete inner VLAN interface
+ip link del $IF.$OUTER_VLAN.$INNER_VLAN
+# Delete outer VLAN interface
+ip link del $IF.$OUTER_VLAN
+
+echo "Deleting uplink interface"
+ip link del $IF.$UPLINK_VLAN
+
+# Remove BNG address from loopback interface
+ip addr del $IPADDR_BNG/29 dev lo

--- a/dhcp-relay/dhcp-relay.h
+++ b/dhcp-relay/dhcp-relay.h
@@ -18,7 +18,10 @@
 #define DHCP_REQUEST 1
 #define DHCP_REPLY 2
 
-#define MAX_LOOPS 40
+#define MAX_LOOPS 20
+#define U16_ASCII_LEN 5	/* Max value: 65535 */
+
+#define IP_ADDR_BCAST 0xFFFFFFFF	/* 255.255.255.255 in hex */
 
 /* Structure for sub-options in option 82 */
 struct sub_option {

--- a/dhcp-relay/dhcp-relay.h
+++ b/dhcp-relay/dhcp-relay.h
@@ -43,6 +43,11 @@ struct dhcp_option_255 {
 	__u8 t;
 };
 
+struct dev_name {
+	char name[IF_NAMESIZE];
+	__u8 len;
+};
+
 struct dhcp_packet {
 	__u8 op; /* 0: Message opcode/type */
 	__u8 htype; /* 1: Hardware addr type (net/if_types.h) */

--- a/dhcp-relay/dhcp-relay.h
+++ b/dhcp-relay/dhcp-relay.h
@@ -45,7 +45,6 @@ struct dhcp_option_255 {
 
 struct dev_name {
 	char name[IF_NAMESIZE];
-	__u8 len;
 };
 
 struct dhcp_packet {

--- a/dhcp-relay/dhcp-relay.h
+++ b/dhcp-relay/dhcp-relay.h
@@ -18,6 +18,8 @@
 #define DHCP_REQUEST 1
 #define DHCP_REPLY 2
 
+#define MAX_LOOPS 40
+
 /* Structure for sub-options in option 82 */
 struct sub_option {
 	__u8 option_id;

--- a/dhcp-relay/dhcp-relay.h
+++ b/dhcp-relay/dhcp-relay.h
@@ -10,7 +10,7 @@
 #define DHO_DHCP_AGENT_OPTIONS 82
 #define RAI_CIRCUIT_ID 1
 #define RAI_REMOTE_ID 2
-#define RAI_OPTION_LEN 40
+#define RAI_OPTION_LEN IF_NAMESIZE
 #define VLAN_ASCII_MAX 4  /* Max bytes needed to store VLAN in ASCII format */
 
 #define DHCP_SERVER_PORT 67
@@ -22,7 +22,7 @@
 struct sub_option {
 	__u8 option_id;
 	__u8 len;
-	char val[IF_NAMESIZE];
+	char val[RAI_OPTION_LEN];
 };
 
 /*structure for dhcp option 82 */

--- a/dhcp-relay/dhcp_kern_xdp.c
+++ b/dhcp-relay/dhcp_kern_xdp.c
@@ -56,36 +56,93 @@ struct {
 	__uint(max_entries, 16384);
 } client_vlans SEC(".maps");
 
-void memcpy_var(void *to, void *from, __u64 len) {
+static int memcpy_var(void *to, void *from, __u8 len) {
 	__u8 *t8 = to, *f8 = from;
 	int i;
 
-	for (i = 0; i < len && i < MAX_LOOPS; i++) {
-		*t8++ = *f8++;		
+	if (len > MAX_LOOPS) {
+		return -1;
 	}
-		
+
+	for (i = 0; i < len; i++) {
+
+		if (i > MAX_LOOPS) {
+			return -1;
+		}
+
+		*t8++ = *f8++;
+
+	}
+
+
+	if (i == MAX_LOOPS)
+		return -1;
+
+	return 0;
+
 }
 
-void memset_var(void *d, __u8 c, __u64 len) {
-	__u8 *d8 = d;
-	int i;
+static int u16_to_ascii(char *buf, __u8 offset, __u16 num) {
 
-	for (i = 0; i < len && i < MAX_LOOPS; i++) {
-		*d8++ = c;
+	__u8 i;
+#pragma unroll U16_ASCII_LEN
+	for (i = offset; i > 0; i--) {
+
+		buf[i - 1] = (num % 10) + '0';
+		num /= 10;
+		if (num == 0)
+			break;
+
 	}
-		
+
+	if (i > 1) {
+		i--;
+		buf[i - 1] = '.';
+	}
+
+	return i - 1;
+
+}
+
+static int str_len(char *buf) {
+
+	__u8 i = 0;
+	for (i = 0; i < IF_NAMESIZE; i++)
+		if (buf[i] == 0)
+			break;
+
+	return i;
+
+}
+
+static int copy_dev_name(char *buf, __u8 offset, char dev[IF_NAMESIZE]) {
+
+	__u8 dev_len = 0;
+
+	dev_len = str_len(dev);
+	
+	/* Check if we have enough space in buffer */
+	if ((offset - dev_len) < 0) {
+		return -1;
+	}
+	
+	offset -= dev_len;
+	
+	memcpy_var(buf + offset, dev, dev_len);
+	
+	return offset;
 }
 
 /* Inserts DHCP option 82 into the received DHCP packet
  * at the specified offset.
  */
 static __always_inline int write_dhcp_option_82(void *ctx, int offset,
-	struct collect_vlans *vlans, char *dev) {
-	
-	struct dhcp_option_82 option;
-	
-	static __u8 buf[RAI_OPTION_LEN];
-	
+		struct collect_vlans *vlans, char dev[IF_NAMESIZE]) {
+
+	struct dhcp_option_82 option = {0};
+
+	static __u8 buf[RAI_OPTION_LEN] = {0};
+
 	option.t = DHO_DHCP_AGENT_OPTIONS;
 	option.len = sizeof (struct sub_option) + sizeof (struct sub_option);
 	option.circuit_id.option_id = RAI_CIRCUIT_ID;
@@ -93,12 +150,6 @@ static __always_inline int write_dhcp_option_82(void *ctx, int offset,
 	option.remote_id.option_id = RAI_REMOTE_ID;
 	option.remote_id.len = sizeof (option.remote_id.val);
 
-	/* Initialize val arrays */
-	memset_var(option.circuit_id.val, 0, sizeof (option.circuit_id.val));
-	memset_var(option.remote_id.val, '*', sizeof (option.remote_id.val));
-	//memset(option.circuit_id.val, 0, sizeof (option.circuit_id.val));
-	//memset(option.remote_id.val, '*', sizeof (option.remote_id.val));
-	
 	/* Reconstruct VLAN device name
 	 * Convert VLAN tags to ASCII from right to left, starting with
 	 * inner VLAN tag.
@@ -106,55 +157,49 @@ static __always_inline int write_dhcp_option_82(void *ctx, int offset,
 	 * contains null bytes.
 	 */
 
-	memset(buf, 0, sizeof (buf));
-	
-	int c = VLAN_ASCII_MAX; /* We will need 4 bytes at most */
-	int i = RAI_OPTION_LEN - 1;
-	
+	int i = RAI_OPTION_LEN;
+
+	// Start with interface name
+	/*int dev_len = str_len(dev, IF_NAMESIZE);
+	if (dev_len < sizeof (option.circuit_id.val)) {
+		memcpy_var(option.circuit_id.val, dev, dev_len);
+	}*/
+
 	__u16 inner_vlan = vlans->id[1];
 	__u16 outer_vlan = vlans->id[0];
 
-	/* Convert inner VLAN to ASCII */
-#pragma unroll VLAN_ASCII_MAX
-	for (c = VLAN_ASCII_MAX; c > 0; c--) {
-		buf[i--] = (inner_vlan % 10) + '0';
-		inner_vlan /= 10;
-		if (inner_vlan == 0) {
-			break;
+	if (inner_vlan != 0) {
+
+		/* Convert inner VLAN to ASCII */
+		i = u16_to_ascii(buf, RAI_OPTION_LEN, inner_vlan);
+		if (i < 0) {
+			return -1;
 		}
+
 	}
 
-	buf[i--] = '.';
+	if (outer_vlan != 0) {
 
-	/* Convert outer VLAN to ASCII */
-#pragma unroll VLAN_ASCII_MAX	
-	for (c = VLAN_ASCII_MAX; c > 0; c--) {
-		buf[i--] = (outer_vlan % 10) + '0';
-		outer_vlan /= 10;
-		if (outer_vlan == 0) {
-			break;
+		/* Convert outer VLAN to ASCII */
+		i = u16_to_ascii(buf, i, outer_vlan);
+		if (i < 0) {
+			return -1;
 		}
+
 	}
 
-	buf[i--] = '.';
+// FIXME: Verifier complains about BPF program being too large when this
+// function is enabled
+//	i = copy_dev_name(buf, i, dev);
+//	if (i < 0)
+//		return -1;
 
-	/* Append interface name */
-#pragma unroll RAI_OPTION_LEN
-	for (c = RAI_OPTION_LEN - 1; c >= 0; c--) {
-		if (dev[c] != 0)
-			buf[i--] = dev[c];
-		if (i < 0)
-			break;	
-	}
-	
-	i++;
-	
-	/* Copy resulting interface name to circuit_id */
 	if (sizeof (option.circuit_id.val) == sizeof (buf)) {
+		
+		/* Copy right-aligned VLAN text to left-aligned buffer */
 		memcpy_var(option.circuit_id.val, buf + i, sizeof (buf) - i);
-		//memcpy_var(option.circuit_id.val, buf, sizeof (buf));
 	}
-	
+
 	return xdp_store_bytes(ctx, offset, &option, sizeof (option), 0);
 }
 
@@ -171,10 +216,10 @@ static __always_inline int write_dhcp_option_255(void *ctx, int offset) {
 
 /* Calculates the IP checksum */
 static __always_inline int calc_ip_csum(struct iphdr *oldip, struct iphdr *ip,
-	__u32 oldcsum) {
+		__u32 oldcsum) {
 	__u32 size = sizeof (struct iphdr);
 	__u32 csum = bpf_csum_diff((__be32 *) oldip, size, (__be32 *) ip, size,
-		~oldcsum);
+			~oldcsum);
 	__u32 sum = (csum >> 16) + (csum & 0xffff);
 	sum += (sum >> 16);
 	return sum;
@@ -189,7 +234,7 @@ static __always_inline int calc_ip_csum(struct iphdr *oldip, struct iphdr *ip,
 	sizeof(struct ethhdr) + sizeof(struct iphdr) + sizeof(struct udphdr) + \
 		offsetof(struct dhcp_packet, options)
 
-/* Delta value to be adjusted at xdp head*/
+/* Delta value for tail adjustment */
 #define delta sizeof(struct dhcp_option_82)
 
 #ifndef DHCP_MAX_OPTIONS
@@ -204,8 +249,6 @@ static __always_inline int calc_ip_csum(struct iphdr *oldip, struct iphdr *ip,
 /* XDP program for parsing the DHCP packet and inserting the option 82*/
 SEC(XDP_PROG_SEC)
 int xdp_dhcp_relay(struct xdp_md *ctx) {
-
-	bpf_printk("\n");
 
 	/* Tail extend packet */
 	int res = bpf_xdp_adjust_tail(ctx, delta);
@@ -236,7 +279,8 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 	__u8 option_length = 0;
 	__u64 client_mac = 0;
 	char *dev;
-	int i = 0;
+	__u8 i = 0;
+	__u8 head_adjusted = 0;
 
 	/* These keep track of the next header type and iterator pointer */
 	struct hdr_cursor nh;
@@ -246,7 +290,6 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 	int len = 0;
 
 	if (data + 1 > data_end) {
-		bpf_printk("Empty packet\n");
 		goto out;
 	}
 
@@ -254,32 +297,31 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 	ether_type = parse_ethhdr_vlan(&nh, data_end, &eth, &vlans);
 	/* check for valid ether type */
 	if (ether_type < 0) {
-		bpf_printk("Cannot determine ethertype\n");
-		goto out;
-	}
-	
-	if (ether_type != bpf_htons(ETH_P_IP)) {
-		//bpf_printk("Ethertype %x is not ETH_P_IP\n", bpf_ntohs(ether_type));
+		bpf_printk("Cannot determine ethertype");
 		goto out;
 	}
 
-	bpf_printk("Ethertype %x\n", bpf_ntohs(ether_type));
-	
-	/* Check at least two vlan tags are present */
-	if (vlans.id[0] == 0) {
-		bpf_printk("No outer VLAN tag set\n");
+	if (ether_type != bpf_htons(ETH_P_IP)) {
+		//bpf_printk("Ethertype %x is not ETH_P_IP", bpf_ntohs(ether_type));
 		goto out;
 	}
-	
-	if (vlans.id[1] == 0) {
-		bpf_printk("No inner VLAN tag set\n");
+
+	/* Check at least one vlan tag is present */
+	if (vlans.id[0] == 0) {
+		bpf_printk("No outer VLAN tag set");
 		goto out;
+	}
+
+	if (vlans.id[1] == 0) {
+		bpf_printk("No inner VLAN tag set");
+		//goto out;
 	}
 
 	h_proto = parse_iphdr(&nh, data_end, &ip);
 
 	/* Only handle fixed-size IP header due to static copy */
 	if (h_proto != IPPROTO_UDP || ip->ihl > 5) {
+		bpf_printk("Not UDP");
 		goto out;
 	}
 
@@ -291,15 +333,17 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 		goto out;
 
 	/* Handle DHCP packets only */
-	if (udp->dest != bpf_htons(DHCP_SERVER_PORT) && udp->dest != bpf_htons(DHCP_CLIENT_PORT))
+	if (udp->dest != bpf_htons(DHCP_SERVER_PORT) && udp->dest != bpf_htons(DHCP_CLIENT_PORT)) {
+		bpf_printk("Not DHCP");
 		goto out;
+	}
 
 	/* Increase IP length header */
 	ip->tot_len += bpf_htons(delta);
 
 	/* Increase UDP length header */
 	udp->len += bpf_htons(delta);
-	
+
 	udp->check = 0;
 
 	/* Read DHCP server IP from config map */
@@ -326,9 +370,8 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 	if (dev == NULL)
 		goto out;
 
-	/* Copy headers of packet to buf */
-	//if (xdp_load_bytes(ctx, 0, buf, static_offset))
-	//	goto out;
+	//memcpy(dev_name, dev, IF_NAMESIZE);
+	//dev_len = str_len(dev_name, IF_NAMESIZE);
 
 	/* Increment offset by 4 bytes for each VLAN (to accomodate VLAN headers */
 #pragma unroll VLAN_MAX_DEPTH
@@ -337,9 +380,6 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 
 			bpf_printk("Found VLAN tag %i at depth %i", vlans.id[i], i);
 
-			/* For each VLAN present, copy 4 bytes of DHCP options to buffer */
-			//if (xdp_load_bytes(ctx, offset, buf + offset, 4))
-			//	goto out;
 			offset += 4;
 			vlan_length += 4;
 		}
@@ -355,6 +395,16 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 	}
 	dhcp = data + vlan_length + dhcp_offset;
 
+	/* Check hops */
+	if (dhcp->hops > 16) {
+		bpf_printk("Max hops exceeded, discarding packet");
+		rc = XDP_ABORTED;
+		goto out;
+	}
+
+	/* Increment hops */
+	dhcp->hops++;
+
 	/* Store client MAC */
 	if (dhcp->chaddr + ETH_ALEN > data_end) {
 		goto out;
@@ -364,11 +414,11 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 	bpf_printk("Parsing DHCP packet, opcode %i, hops %i", dhcp->op, dhcp->hops);
 
 	if (dhcp->op == DHCP_REQUEST && (eth->h_dest[0] == 0xff
-		&& eth->h_dest[1] == 0xff
-		&& eth->h_dest[2] == 0xff
-		&& eth->h_dest[3] == 0xff
-		&& eth->h_dest[4] == 0xff
-		&& eth->h_dest[5] == 0xff)) {
+			&& eth->h_dest[1] == 0xff
+			&& eth->h_dest[2] == 0xff
+			&& eth->h_dest[3] == 0xff
+			&& eth->h_dest[4] == 0xff
+			&& eth->h_dest[5] == 0xff)) {
 
 		/* Request from client received as broadcast */
 
@@ -395,24 +445,15 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 
 
 	} else if (dhcp->op == DHCP_REPLY && (eth->h_dest[0] != 0xff
-		|| eth->h_dest[1] != 0xff
-		|| eth->h_dest[2] != 0xff
-		|| eth->h_dest[3] != 0xff
-		|| eth->h_dest[4] != 0xff
-		|| eth->h_dest[5] != 0xff)) {
+			|| eth->h_dest[1] != 0xff
+			|| eth->h_dest[2] != 0xff
+			|| eth->h_dest[3] != 0xff
+			|| eth->h_dest[4] != 0xff
+			|| eth->h_dest[5] != 0xff)) {
 
 		/* Response from server received as unicast */
 
 		bpf_printk("Unicast packet received, opcode %i, hops %i", dhcp->op, dhcp->hops);
-
-		/* FIXME: Add code for reply packets
-		 * Basically:
-		 * - Set dest and src MAC
-		 * - Add VLAN tags
-		 * - Remove option 82
-		 * - Use XDP_TX (or XDP_REDIRECT) to send the response
-		 * to the end user
-		 */
 
 		struct collect_vlans *new_vlans;
 		new_vlans = bpf_map_lookup_elem(&client_vlans, &client_mac);
@@ -421,19 +462,89 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 			goto out;
 		}
 
-		bpf_printk("Found map entry for MAC %i", client_mac);
+		bpf_printk("Found map entry for MAC %x", client_mac);
+
+		/* Set destination MAC */
+		memcpy(eth->h_dest, dhcp->chaddr, ETH_ALEN);
+
+		/* Set source MAC */
+		memcpy(eth->h_source, relay_hwaddr, ETH_ALEN);
+
+		/* Set destination IP */
+		ip->daddr = IP_ADDR_BCAST;
+
+		/* Set source IP */
+		ip->saddr = *relay_agent_ip;
+
+		/* Add / replace VLAN tags */
+		if (vlans.id[0] != 0) {
+			bpf_printk("Outer VLAN %i found, will change to %i", vlans.id[0], new_vlans->id[0]);
+
+			struct vlan_hdr *outer_vlh = data + ETH_HLEN;
+			outer_vlh->h_vlan_TCI = bpf_htons((bpf_ntohs(outer_vlh->h_vlan_TCI) & 0xf000) | new_vlans->id[0]);
+
+		}
+
+		if (vlans.id[1] != 0) {
+			bpf_printk("Inner VLAN %i found, will change to %i", vlans.id[1], new_vlans->id[1]);
+
+			struct vlan_hdr *inner_vlh = data + ETH_HLEN + sizeof (struct vlan_hdr);
+			inner_vlh->h_vlan_TCI = bpf_htons((bpf_ntohs(inner_vlh->h_vlan_TCI) & 0xf000) | new_vlans->id[1]);
+
+		} else {
+			bpf_printk("Inner VLAN not found, will insert %i", new_vlans->id[1]);
+
+			/* Adjust header by -4 bytes to make space for VLAN header */
+			if (bpf_xdp_adjust_head(ctx, -(int) sizeof (struct vlan_hdr))) {
+				bpf_printk("Cannot head-adjust packet by %i bytes, aborting", -(int) sizeof (struct vlan_hdr));
+				rc = XDP_ABORTED;
+				goto out;
+			}
+
+			bpf_printk("Head-adjusted packet by %i bytes", -(int) sizeof (struct vlan_hdr));
+
+			head_adjusted = 1;
+
+			data_end = (void *) (long) ctx->data_end;
+			data = (void *) (long) ctx->data;
+
+			/* Verifier check */
+			if (data + ETH_ALEN + ETH_ALEN + sizeof (struct vlan_hdr) + sizeof (struct vlan_hdr) > data_end) {
+				rc = XDP_ABORTED;
+				goto out;
+			}
+			
+			/* Move MAC address headers + outer VLAN tag to beginning of packet */
+			memmove(data, data + sizeof (struct vlan_hdr), ETH_ALEN + ETH_ALEN + sizeof (struct vlan_hdr));
+
+			bpf_printk("Moved %i bytes from offset %i to offset %i", ETH_ALEN + ETH_ALEN + sizeof (struct vlan_hdr), sizeof (struct vlan_hdr), 0);
+
+			/* Make new inner VLAN header (copy from outer VLAN header) */
+			memcpy(data + ETH_ALEN + ETH_ALEN + sizeof (struct vlan_hdr), data + ETH_ALEN + ETH_ALEN, sizeof (struct vlan_hdr));
+
+			bpf_printk("Copied %i bytes from offset %i to offset %i", sizeof (struct vlan_hdr), ETH_ALEN + ETH_ALEN, ETH_ALEN + ETH_ALEN + sizeof (struct vlan_hdr));
+
+			bpf_printk("Will modify VLAN header at offset %i", ETH_ALEN + ETH_ALEN + sizeof (struct vlan_hdr));
+
+			struct vlan_hdr *vlh = data + ETH_ALEN + ETH_ALEN + sizeof (struct vlan_hdr) + 2;
+			vlh->h_vlan_TCI = bpf_htons((bpf_ntohs(vlh->h_vlan_TCI) & 0xf000) | new_vlans->id[1]);
+
+			offset += sizeof (struct vlan_hdr);
+			vlan_length += sizeof (struct vlan_hdr);
+
+			/* Parse DHCP packet */
+			if (data + vlan_length + dhcp_offset + sizeof (dhcp) > data_end) {
+				goto out;
+			}
+			dhcp = data + vlan_length + dhcp_offset;
+
+			bpf_printk("Inserted VLAN header");
+
+		}
+
+		rc = XDP_TX;
 
 	}
-
-	/* Check hops */
-	if (dhcp->hops > 16) {
-		bpf_printk("Max hops exceeded, discarding packet");
-		rc = XDP_ABORTED;
-		goto out;
-	}
-
-	/* Increment hops */
-	dhcp->hops++;
 
 	/* Check if we exceed boundaries to make verifier happy */
 	if (data + offset > data_end)
@@ -451,20 +562,33 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 		if (pos + 1 > data_end)
 			break;
 
+		/* Read option code */
 		option_code = *pos;
 
 		bpf_printk("Got option code %i at offset %i, hex %x", option_code, option_offset, option_offset);
 
+		if (option_code == 82 && dhcp->op == DHCP_REPLY) {
+
+			bpf_printk("Will erase DHCP option 82");
+
+			/* FIXME: Erase options 82 + 255 and set new option 255 */
+
+			*pos = 255;
+			break;
+
+		}
+
 		if (option_code == 255) {
 
-			bpf_printk("Going to write DHCP option at offset %i", option_offset);
+			bpf_printk("Going to write DHCP option 82 at offset %i", option_offset);
 
 			/* Insert Option 82 before END option */
 			if (write_dhcp_option_82(ctx, option_offset, &vlans, dev)) {
 				bpf_printk("Could not write DHCP option 82 at offset %i", option_offset);
-				return XDP_ABORTED;
+				//return XDP_ABORTED;
+				break;
 			}
-			
+
 			/* Set END option */
 
 			/* Verifier check */
@@ -476,57 +600,50 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 
 			if (write_dhcp_option_255(ctx, option_offset)) {
 				bpf_printk("Could not write DHCP option 255 at offset %i", option_offset);
-				return XDP_ABORTED;
+				//return XDP_ABORTED;
+				break;
 			}
 
 			bpf_printk("Wrote DHCP option 255 at offset %i, returning XDP_PASS", option_offset);
 
 			break;
 		}
+
 		pos++;
+
+		/* Verifier check */
+		if (pos + 1 > data_end) {
+			break;
+		}
 
 		option_length = *pos;
 		option_offset += option_length + 2;
 
+		/* Verifier check */
 		if (pos + 1 > data_end) {
 			break;
 		}
 		pos++;
 
+		/* Verifier check */
 		if (pos + option_length > data_end) {
 			break;
 		}
+
+		/* Skip option value (go to next option) */
 		pos += option_length;
 
 	}
 
-	//return XDP_PASS;
-
-	/* Copy stored headers from buf to context */
-	/*if (xdp_store_bytes(ctx, 0, buf, static_offset, 0)) {
-
-		bpf_printk("xdp_store_bytes(ctx, 0, buf, %i) failed", static_offset);
-		return XDP_ABORTED;
-	}*/
-
-
-	/* make space for option 82 - copy DHCP options after increasing offset */
-	/*if (offset > static_offset) {
-		offset = static_offset;
-		for (i = 0; i < VLAN_MAX_DEPTH; i++) {
-			if (vlans.id[i]) {*/
-	/*  */
-	/*if (xdp_store_bytes(ctx, offset, buf + offset,
-		4, 0))
-		return XDP_ABORTED;
-	offset += 4;
-}
+	/* Adjust IP offset for VLAN header when VLAN header has been added */
+	if (head_adjusted) {
+		ip = data + ip_offset + sizeof (struct vlan_hdr);
+	} else {
+		ip = data + ip_offset;
 	}
-	}*/
-
-	ip = data + ip_offset;
-	if (ip + 1 > data_end)
+	if (ip + 1 > data_end) {
 		return XDP_ABORTED;
+	}
 
 	/* Overwrite the destination IP in IP header */
 	ip->daddr = *dhcp_srv_ip;
@@ -537,7 +654,6 @@ int xdp_dhcp_relay(struct xdp_md *ctx) {
 	/* Re-calculate ip checksum */
 	__u32 sum = calc_ip_csum(&oldip, ip, oldip.check);
 	ip->check = ~sum;
-	rc = XDP_PASS;
 
 	goto out;
 

--- a/dhcp-relay/dhcp_user_xdp.c
+++ b/dhcp-relay/dhcp_user_xdp.c
@@ -113,54 +113,54 @@ int main(int argc, char **argv) {
 	unsigned char *mac;
 	struct ifreq ifr;
 
-	while ((opt = getopt_long(argc, argv, "hui:d:m:s:", options, NULL)) !=
-		-1) {
+	while ((opt = getopt_long(argc, argv, "hui:d:m:s:", options, NULL)) != -1) {
 		switch (opt) {
-			case 'i':	/* Physical interface */
-				strncpy(dev, optarg, IF_NAMESIZE);
-				dev[IF_NAMESIZE - 1] = '\0';
-				ifindex = if_nametoindex(dev);
-				if (ifindex <= 0) {
-					printf("Couldn't find ifname:%s \n", dev);
-					return -EINVAL;
-				}
-				break;
-			case 'd':	/* DHCP server address */
-				if (inet_aton(optarg, &dhcp_server_addr) == 0) {
-					fprintf(stderr,
-						"Couldn't validate DHCP server IP address:%s\n",
-						optarg);
-					return -EINVAL;
-				}
-				dhcp_server_addr_set = true;
-				break;
-			case 's':	/* Relay agent address */
-				if (inet_aton(optarg, &relay_agent_addr) == 0) {
-					fprintf(stderr,
-						"Couldn't validate relay agent IP address:%s\n",
-						optarg);
-					return -EINVAL;
-				}
-				relay_agent_addr_set = true;
-				break;
-			case 'm':	/* Mode: skb or native */
-				if (strcmp(optarg, "skb") == 0) {
-					xdp_flags = XDP_FLAGS_SKB_MODE;
-				} else if (strcmp(optarg, "drv") != 0) {
-					fprintf(stderr, "Invalid mode: %s\n", optarg);
-					return -EINVAL;
-				}
-
-				break;
-			case 'u':	/* Unload XDP program */
-				do_unload = 1;
-				break;
-			case 'h':	/* Help menu */
-				print_usage(argv);
-				exit(0);
-			default:
-				fprintf(stderr, "Unknown option %s\n", argv[optind]);
+		case 'i':	/* Physical interface */
+			strncpy(dev, optarg, IF_NAMESIZE);
+			dev[IF_NAMESIZE - 1] = '\0';
+			ifindex = if_nametoindex(dev);
+			if (ifindex <= 0) {
+				printf("Couldn't find ifname:%s \n", dev);
 				return -EINVAL;
+			}
+			break;
+		case 'd':	/* DHCP server address */
+			if (inet_aton(optarg, &dhcp_server_addr) == 0) {
+				fprintf(stderr,
+					"Couldn't validate DHCP server IP address:%s\n",
+					optarg);
+				return -EINVAL;
+			}
+			dhcp_server_addr_set = true;
+			break;
+		case 's':	/* Relay agent address */
+			if (inet_aton(optarg, &relay_agent_addr) == 0) {
+				fprintf(stderr,
+					"Couldn't validate relay agent IP address:%s\n",
+					optarg);
+				return -EINVAL;
+			}
+			relay_agent_addr_set = true;
+			break;
+		case 'm':	/* Mode: skb or native */
+			if (strcmp(optarg, "skb") == 0) {
+				xdp_flags = XDP_FLAGS_SKB_MODE;
+			} else if (strcmp(optarg, "drv") != 0) {
+				fprintf(stderr, "Invalid mode: %s\n", optarg);
+				return -EINVAL;
+			}
+
+			break;
+		case 'u':	/* Unload XDP program */
+			do_unload = 1;
+			break;
+
+		case 'h':	/* Help menu */
+			print_usage(argv);
+			exit(0);
+		default:
+			fprintf(stderr, "Unknown option %s\n", argv[optind]);
+			return -EINVAL;
 		}
 	}
 

--- a/dhcp-relay/dhcp_user_xdp.c
+++ b/dhcp-relay/dhcp_user_xdp.c
@@ -28,6 +28,7 @@ static const struct option options[] = {
 	{ "relay-agent-address", required_argument, NULL, 's'},
 	{ "mode", required_argument, NULL, 'm'},
 	{ "unload", no_argument, NULL, 'u'},
+	{ "verbose", no_argument, NULL, 'v'},
 	{ 0, 0, NULL, 0}
 };
 
@@ -89,6 +90,13 @@ int xdp_link_attach(int ifindex, __u32 xdp_flags, int prog_fd) {
 	return 0;
 }
 
+static int libbpf_print_func(enum libbpf_print_level level, const char *format,
+			     va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+
 int main(int argc, char **argv) {
 
 	char filename[256] = "dhcp_kern_xdp.o";
@@ -113,7 +121,7 @@ int main(int argc, char **argv) {
 	unsigned char *mac;
 	struct ifreq ifr;
 
-	while ((opt = getopt_long(argc, argv, "hui:d:m:s:", options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "huvi:d:m:s:", options, NULL)) != -1) {
 		switch (opt) {
 		case 'i':	/* Physical interface */
 			strncpy(dev, optarg, IF_NAMESIZE);
@@ -153,6 +161,10 @@ int main(int argc, char **argv) {
 			break;
 		case 'u':	/* Unload XDP program */
 			do_unload = 1;
+			break;
+
+		case 'v':	/* Verbose libbpf logging */
+			libbpf_set_print(libbpf_print_func);
 			break;
 
 		case 'h':	/* Help menu */

--- a/dhcp-relay/test.sh
+++ b/dhcp-relay/test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash -x
+
+OUTER_VLAN=83
+INNER_VLAN=20
+UPLINK_VLAN=84
+IF="ens6f0"
+
+DHCP_SERVER="185.107.12.59"
+IPADDR_BNG="194.45.77.57"
+IPADDR_UPLINK="185.107.12.99"
+UPLINK_GW="185.107.12.97"
+CLIENT_IP="194.45.77.59"
+
+echo "Setting up VLAN interfaces"
+ethtool -K $IF txvlan off
+ethtool -K $IF rxvlan off
+# Increase MTU to allow second VLAN tag (QinQ)
+ip link set dev $IF mtu 1504
+ip link set dev $IF up
+# Set outer VLAN interface
+ip link add link $IF name $IF.$OUTER_VLAN type vlan id $OUTER_VLAN
+ip link set $IF.$OUTER_VLAN up
+
+CLIENT_IF=$IF.$OUTER_VLAN.$INNER_VLAN
+
+# Set inner VLAN interface
+ip link add link $IF.$OUTER_VLAN name $CLIENT_IF type vlan id $INNER_VLAN
+ip link set $CLIENT_IF up
+
+# Set accept_local for VLAN interface
+echo 1 > /proc/sys/net/ipv4/conf/$CLIENT_IF/accept_local
+
+# Disable reverse path filtering for VLAN interface
+echo 0 > /proc/sys/net/ipv4/conf/$CLIENT_IF/rp_filter
+
+# Enable ARP proxy for VLAN interface
+echo 1 > /proc/sys/net/ipv4/conf/$CLIENT_IF/proxy_arp
+
+# Insert /32 route to client
+ip route add $CLIENT_IP/32 dev $CLIENT_IF
+
+# Set IP forwarding
+echo 1 > /proc/sys/net/ipv4/ip_forward
+
+# Set L3 config for BNG interface
+ip addr add $IPADDR_BNG/29 dev lo
+
+# Create upstream interface
+ip link add link $IF name $IF.$UPLINK_VLAN type vlan id $UPLINK_VLAN
+ip link set dev $IF.$UPLINK_VLAN
+ip link set $IF.$UPLINK_VLAN up
+
+# Disable RP filtering globally to receive DHCP requests through unnumbered
+# interface
+echo 0 > /proc/sys/net/ipv4/conf/all/rp_filter
+
+# Set L3 config for upstream interface
+ip addr add $IPADDR_UPLINK/28 dev $IF.$UPLINK_VLAN
+ip route replace default via $UPLINK_GW
+
+echo "Compiling XDP program"
+make
+
+echo "Launching XDP program"
+./dhcp_user_xdp -i $IF -d $DHCP_SERVER -s $IPADDR_UPLINK

--- a/dhcp-relay/trace.sh
+++ b/dhcp-relay/trace.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -x
+
+cat /sys/kernel/debug/tracing/trace_pipe


### PR DESCRIPTION
This version works with kernel 5.15 and LLVM 13.

Improvements:

- Interface name is added to Option 82 Circuit ID
- On server replies, Option 82 is wiped completely
- Char array parameters replaced with structs

Functions that previously used char arrays as function parameters now
use structs instead - otherwise the verifier cannot perform proper
boundary checks.

To-do:
- IPv6 support
- Multiple interface support